### PR TITLE
drvgen: avoid using py-drvgen

### DIFF
--- a/scripts/drvgen/drvgen.mk
+++ b/scripts/drvgen/drvgen.mk
@@ -67,7 +67,8 @@ $(DRVGEN_FILE_LIST): $(DRVGEN_TOOL) $(DWS_FILE) $(DRVGEN_FIG) $(PROJ_DTS_FILES)
 		dws_path=$(srctree)/$(DRVGEN_PATH)/$$base_prj.dws ;\
 		if [ -f $$dws_path ] ; then \
 			mkdir -p $$prj_path;\
-			($(DRVGEN_TOOL_OLD) $$dws_path $$prj_path $$prj_path cust_dtsi); \
+			($(DRVGEN_TOOL_OLD) $$dws_path $$prj_path $$prj_path cust_dtsi) \
+		 || ($(python) $(DRVGEN_TOOL) $$dws_path $$prj_path $$prj_path cust_dtsi); \
 		fi \
 	done
 

--- a/scripts/drvgen/drvgen.mk
+++ b/scripts/drvgen/drvgen.mk
@@ -54,6 +54,7 @@ else
 DRVGEN_FILE_LIST :=
 endif
 DRVGEN_TOOL := $(srctree)/tools/dct/DrvGen.py
+DRVGEN_TOOL_OLD := $(srctree)/tools/dct/old_dct/DrvGen
 DRVGEN_FIG := $(wildcard $(dir $(DRVGEN_TOOL))config/*.fig)
 
 .PHONY: drvgen
@@ -65,8 +66,8 @@ $(DRVGEN_FILE_LIST): $(DRVGEN_TOOL) $(DWS_FILE) $(DRVGEN_FIG) $(PROJ_DTS_FILES)
 		prj_path=$(DRVGEN_OUT)/$$base_prj ;\
 		dws_path=$(srctree)/$(DRVGEN_PATH)/$$base_prj.dws ;\
 		if [ -f $$dws_path ] ; then \
-			mkdir -p $$prj_path ;\
-			$(python) $(DRVGEN_TOOL) $$dws_path $$prj_path $$prj_path cust_dtsi;\
+			mkdir -p $$prj_path;\
+			($(DRVGEN_TOOL_OLD) $$dws_path $$prj_path $$prj_path cust_dtsi); \
 		fi \
 	done
 


### PR DESCRIPTION
hop over to [`Issues#5`](https://github.com/parthibx24/android_kernel_mediatek_k80/issues/5) for more info.