### PR TITLE
kernel-4.9: compile empty built-in correctly

### DIFF
--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -490,13 +490,12 @@ endif
 ifdef CONFIG_THIN_ARCHIVES
   cmd_make_builtin = $(update_lto_symversions)	\
 	rm -f $@; $(AR) rcSTP$(KBUILD_ARFLAGS)
-  cmd_make_empty_builtin = rm -f $@; $(AR) rcSTP$(KBUILD_ARFLAGS)
   quiet_cmd_link_o_target = AR      $@
 else
   cmd_make_builtin = $(LD) $(ld_flags) -r -o
-  cmd_make_empty_builtin = rm -f $@; $(AR) rcs$(KBUILD_ARFLAGS)
   quiet_cmd_link_o_target = LD      $@
 endif
+cmd_make_empty_builtin = rm -f $@; echo "" | gcc -c -x c - -o
 
 # If the list of objects to link is empty, just create an empty built-in.o
 cmd_link_o_target = $(if $(strip $(obj-y)),\


### PR DESCRIPTION
not backporting from master because its too much work and this method is more easier. [`Issue#4`](https://github.com/parthibx24/android_kernel_mediatek_k80/issues/4)